### PR TITLE
add intensity value for input points

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -81,8 +81,14 @@ def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
         mask = np.isfinite(cloud_array['x']) & np.isfinite(cloud_array['y']) & np.isfinite(cloud_array['z'])
         cloud_array = cloud_array[mask]
 
+    # Check if intensity field exists
+    has_intensity = 'intensity' in cloud_array.dtype.names
+
     points = np.zeros(cloud_array.shape + (4,), dtype=dtype)
     points[...,0] = cloud_array['x']
     points[...,1] = cloud_array['y']
     points[...,2] = cloud_array['z']
+    # Optionally fill in intensity values if available
+    if has_intensity:
+        points[..., 3] = cloud_array['intensity']
     return points


### PR DESCRIPTION
Hello Mrs Zhang

I'm Jane, a couple of weeks ago I ask a issue about [the poor detection result when using custom dataset](https://github.com/Kin-Zhang/OpenPCDet_ros/issues/15) and now I've solved it and want to create a pull request for you.

The reason why the result seemed not so well is that the input points don't have a intensity value. And now I add this value, so the points format becomes (x,y,z,intensity).

``` python
def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
    """
    """
    if remove_nans:
        mask = np.isfinite(cloud_array['x']) & np.isfinite(cloud_array['y']) & np.isfinite(cloud_array['z'])
        cloud_array = cloud_array[mask]

    # Check if intensity field exists
    has_intensity = 'intensity' in cloud_array.dtype.names

    points = np.zeros(cloud_array.shape + (4,), dtype=dtype)
    points[...,0] = cloud_array['x']
    points[...,1] = cloud_array['y']
    points[...,2] = cloud_array['z']
    # Optionally fill in intensity values if available
    if has_intensity:
        points[..., 3] = cloud_array['intensity']
    return points
```

Thank you for your suggestion, it is the problem about the input data.

Looking forward to your inspection.